### PR TITLE
Local twilio verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Local verification codes will expire after 10 minutes.
 
 > Note that your verification codes will be stored using your configured Laravel cache driver.
 
+Of course, when using locally generated codes, we still need to update Twilio with the status of the verification. To support this, we will automatically dispatch a queued listener
+to update Twilio after a verification is completed.
+
 ## Usage
 
 To use this package, you'll want to inject the `\Worksome\VerifyByPhone\Contracts\PhoneVerificationService`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ under `driver`, or by using the dedicated `.env` variable: `VERIFY_BY_PHONE_DRIV
 To use our Twilio integration, you'll need to provide an `account_sid`, `auth_token` and `verify_sid`. All of these can
 be set in the `config/verify-by-phone.php` file under `services.twilio`.
 
+By default, the Twilio integration will delegate the creation, storage and verification of codes to the Twilio platform.
+However, we also provide support for creating, storing and verifying codes locally. This speeds up the process of verification
+for your end users. To enable support for this, set the `services.twilio.generate_codes_locally` config variable to `true` in the `config/verify-by-phone.php` file.
+Local verification codes will expire after 10 minutes.
+
+> Note that your verification codes will be stored using your configured Laravel cache driver.
+
 ## Usage
 
 To use this package, you'll want to inject the `\Worksome\VerifyByPhone\Contracts\PhoneVerificationService`

--- a/config/verify-by-phone.php
+++ b/config/verify-by-phone.php
@@ -15,6 +15,7 @@ return [
             'account_sid' => env('TWILIO_ACCOUNT_SID'),
             'auth_token' => env('TWILIO_AUTH_TOKEN'),
             'verify_sid' => env('TWILIO_VERIFY_SID'),
+            'generate_code_locally' => false,
         ],
 
     ],

--- a/config/verify-by-phone.php
+++ b/config/verify-by-phone.php
@@ -15,7 +15,7 @@ return [
             'account_sid' => env('TWILIO_ACCOUNT_SID'),
             'auth_token' => env('TWILIO_AUTH_TOKEN'),
             'verify_sid' => env('TWILIO_VERIFY_SID'),
-            'generate_code_locally' => false,
+            'generate_codes_locally' => false,
         ],
 
     ],

--- a/src/Contracts/InformsServiceAfterVerification.php
+++ b/src/Contracts/InformsServiceAfterVerification.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\Contracts;
+
+use Propaganistas\LaravelPhone\PhoneNumber;
+
+interface InformsServiceAfterVerification
+{
+    public function informService(PhoneNumber $phoneNumber, bool $isVerified): void;
+}

--- a/src/Contracts/VerificationCodeGenerator.php
+++ b/src/Contracts/VerificationCodeGenerator.php
@@ -8,10 +8,8 @@ use Propaganistas\LaravelPhone\PhoneNumber;
 
 interface VerificationCodeGenerator
 {
-
     /**
      * Generate a verification code that will be sent to the user.
      */
     public function generate(PhoneNumber $phoneNumber): string;
-
 }

--- a/src/Contracts/VerificationCodeGenerator.php
+++ b/src/Contracts/VerificationCodeGenerator.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\Contracts;
+
+use Propaganistas\LaravelPhone\PhoneNumber;
+
+interface VerificationCodeGenerator
+{
+
+    /**
+     * Generate a verification code that will be sent to the user.
+     */
+    public function generate(PhoneNumber $phoneNumber): string;
+
+}

--- a/src/Contracts/VerificationCodeManager.php
+++ b/src/Contracts/VerificationCodeManager.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\Contracts;
+
+use Propaganistas\LaravelPhone\PhoneNumber;
+
+interface VerificationCodeManager
+{
+    /**
+     * Store a new verification code for the given phone number.
+     */
+    public function store(PhoneNumber $phoneNumber): string;
+
+    /**
+     * Retrieve the stored verification code for the given phone number.
+     */
+    public function retrieve(PhoneNumber $phoneNumber): null|string;
+}

--- a/src/Events/PhoneNumberVerified.php
+++ b/src/Events/PhoneNumberVerified.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\Events;
+
+use Propaganistas\LaravelPhone\PhoneNumber;
+
+final class PhoneNumberVerified
+{
+    public function __construct(
+        public PhoneNumber $phoneNumber,
+        public string $code,
+        public bool $isVerified,
+    ) {
+    }
+}

--- a/src/Exceptions/UnknownVerificationErrorException.php
+++ b/src/Exceptions/UnknownVerificationErrorException.php
@@ -14,7 +14,7 @@ final class UnknownVerificationErrorException extends Exception
         parent::__construct("Something went wrong while verifying sms code.", 0, $previous);
     }
 
-    public static function fromException(Exception $exception): self
+    public static function fromException(Throwable $exception): self
     {
         return new self($exception);
     }

--- a/src/Listeners/InformServiceOfVerificationStatus.php
+++ b/src/Listeners/InformServiceOfVerificationStatus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Worksome\VerifyByPhone\Contracts\InformsServiceAfterVerification;
+use Worksome\VerifyByPhone\Contracts\PhoneVerificationService;
+use Worksome\VerifyByPhone\Events\PhoneNumberVerified;
+
+/**
+ * @internal
+ */
+final class InformServiceOfVerificationStatus implements ShouldQueue
+{
+    public int $tries = 5;
+
+    public function __construct(private PhoneVerificationService $verificationService)
+    {
+    }
+
+    public function handle(PhoneNumberVerified $event): void
+    {
+        /** @var InformsServiceAfterVerification $service */
+        $service = $this->verificationService;
+
+        $service->informService($event->phoneNumber, $event->isVerified);
+    }
+
+    public function shouldQueue(PhoneNumberVerified $event): bool
+    {
+        return $this->verificationService instanceof InformsServiceAfterVerification;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [1, 5, 10, 60, 60];
+    }
+}

--- a/src/Services/Twilio/TwilioVerificationService.php
+++ b/src/Services/Twilio/TwilioVerificationService.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Worksome\VerifyByPhone\Services\Twilio;
 
+use Exception;
 use Propaganistas\LaravelPhone\PhoneNumber;
+use Throwable;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Rest\Client;
 use Twilio\Rest\Verify\V2\Service\VerificationCheckList;
 use Twilio\Rest\Verify\V2\Service\VerificationList;
 use Worksome\VerifyByPhone\Contracts\PhoneVerificationService;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
 use Worksome\VerifyByPhone\Exceptions\FailedSendingVerificationCodeException;
 use Worksome\VerifyByPhone\Exceptions\UnknownVerificationErrorException;
 use Worksome\VerifyByPhone\Exceptions\UnsupportedNumberException;
@@ -26,8 +29,11 @@ final class TwilioVerificationService implements PhoneVerificationService
     private VerificationList $verifications;
     private VerificationCheckList $verificationChecks;
 
-    public function __construct(Client $twilio, string $verifyId)
-    {
+    public function __construct(
+        Client $twilio,
+        string $verifyId,
+        private ?VerificationCodeManager $verificationCodeManager,
+    ) {
         $twilio = $twilio->verify->v2->services($verifyId);
         $this->verifications = $twilio->verifications;
         $this->verificationChecks = $twilio->verificationChecks;
@@ -36,7 +42,7 @@ final class TwilioVerificationService implements PhoneVerificationService
     public function send(PhoneNumber $number): void
     {
         try {
-            $this->verifications->create($number->formatE164(), 'sms');
+            $this->verifications->create($number->formatE164(), 'sms', $this->getSendOptions($number));
         } catch (TwilioException $e) {
             throw match ($e->getCode()) {
                 self::ERROR_NUMBER_DOES_NOT_SUPPORT_SMS => UnsupportedNumberException::fromException($e),
@@ -45,20 +51,51 @@ final class TwilioVerificationService implements PhoneVerificationService
         }
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSendOptions(PhoneNumber $number): array
+    {
+        $options = [];
+
+        if ($this->isUsingLocallyGeneratedCodes()) {
+            $options['customCode'] = $this->verificationCodeManager?->store($number);
+        }
+
+        return $options;
+    }
+
     public function verify(PhoneNumber $number, string $code): bool
     {
         try {
-            $response = $this->verificationChecks->create(
-                $code,
-                ['to' => $number->formatE164()]
-            );
-        } catch (TwilioException $e) {
+            return $this->codeIsValid($number, $code);
+        } catch (Throwable $e) {
             throw match ($e->getCode()) {
                 self::ERROR_NOT_FOUND => VerificationCodeExpiredException::fromException($e),
                 default => UnknownVerificationErrorException::fromException($e),
             };
         }
+    }
 
-        return $response->status === 'approved';
+    /**
+     * @throws TwilioException
+     * @throws Exception
+     */
+    private function codeIsValid(PhoneNumber $number, string $code): bool
+    {
+        if (! $this->isUsingLocallyGeneratedCodes()) {
+            return $this->verificationChecks->create($code, ['to' => $number->formatE164()])->status === 'approved';
+        }
+
+        $storedCode = $this->verificationCodeManager?->retrieve($number);
+
+        throw_unless($storedCode, new Exception('The verification code is not stored locally', self::ERROR_NOT_FOUND));
+
+        return $code === $storedCode;
+    }
+
+    private function isUsingLocallyGeneratedCodes(): bool
+    {
+        return $this->verificationCodeManager !== null;
     }
 }

--- a/src/VerificationCodeGenerators/NumericVerificationCodeGenerator.php
+++ b/src/VerificationCodeGenerators/NumericVerificationCodeGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\VerificationCodeGenerators;
+
+use Illuminate\Support\Collection;
+use Propaganistas\LaravelPhone\PhoneNumber;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeGenerator;
+
+final class NumericVerificationCodeGenerator implements VerificationCodeGenerator
+{
+    private const CODE_LENGTH = 6;
+
+    public function generate(PhoneNumber $phoneNumber): string
+    {
+        return Collection::times(self::CODE_LENGTH, fn () => mt_rand(0, 9))->join('');
+    }
+}

--- a/src/VerificationCodeManagers/CacheVerificationCodeManager.php
+++ b/src/VerificationCodeManagers/CacheVerificationCodeManager.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\VerifyByPhone\VerificationCodeManagers;
+
+use Illuminate\Contracts\Cache\Repository;
+use Propaganistas\LaravelPhone\PhoneNumber;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeGenerator;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
+
+final class CacheVerificationCodeManager implements VerificationCodeManager
+{
+    public function __construct(
+        private Repository $cache,
+        private VerificationCodeGenerator $codeGenerator,
+    ) {
+    }
+
+    public function store(PhoneNumber $phoneNumber): string
+    {
+        $code = $this->codeGenerator->generate($phoneNumber);
+        $this->cache->put($this->getCacheKey($phoneNumber), $code, 60 * 5);
+
+        return $code;
+    }
+
+    public function retrieve(PhoneNumber $phoneNumber): null|string
+    {
+        $result = $this->cache->get($this->getCacheKey($phoneNumber));
+
+        return is_string($result) ? $result : null;
+    }
+
+    private function getCacheKey(PhoneNumber $phoneNumber): string
+    {
+        return "verify-by-phone.verification-code.{$phoneNumber->serialize()}";
+    }
+}

--- a/src/VerificationCodeManagers/CacheVerificationCodeManager.php
+++ b/src/VerificationCodeManagers/CacheVerificationCodeManager.php
@@ -20,7 +20,7 @@ final class CacheVerificationCodeManager implements VerificationCodeManager
     public function store(PhoneNumber $phoneNumber): string
     {
         $code = $this->codeGenerator->generate($phoneNumber);
-        $this->cache->put($this->getCacheKey($phoneNumber), $code, 60 * 5);
+        $this->cache->put($this->getCacheKey($phoneNumber), $code, 60 * 10);
 
         return $code;
     }

--- a/src/VerifyByPhoneManager.php
+++ b/src/VerifyByPhoneManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Worksome\VerifyByPhone;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Manager;
 use Twilio\Rest\Client;
 use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
@@ -27,17 +28,31 @@ class VerifyByPhoneManager extends Manager
 
     public function createTwilioDriver(): TwilioVerificationService
     {
-        /** @var Client $client */
-        $client = $this->container->make(Client::class);
-        /** @var VerificationCodeManager $verificationCodeManager */
-        $verificationCodeManager = $this->container->make(VerificationCodeManager::class);
-
         $generateCodeLocally = boolval($this->config->get('verify-by-phone.services.twilio.generate_codes_locally', false));
 
         return new TwilioVerificationService(
-            $client,
+            $this->getTwilioClient(),
             strval($this->config->get('verify-by-phone.services.twilio.verify_sid')),
-            $generateCodeLocally ? $verificationCodeManager : null
+            $generateCodeLocally ? $this->getVerificationCodeManager() : null,
+            $this->getEventDispatcher(),
         );
+    }
+
+    private function getTwilioClient(): Client
+    {
+        // @phpstan-ignore-next-line
+        return $this->container->make(Client::class);
+    }
+
+    private function getVerificationCodeManager(): VerificationCodeManager
+    {
+        // @phpstan-ignore-next-line
+        return $this->container->make(VerificationCodeManager::class);
+    }
+
+    private function getEventDispatcher(): Dispatcher
+    {
+        // @phpstan-ignore-next-line
+        return $this->container->make('events');
     }
 }

--- a/src/VerifyByPhoneManager.php
+++ b/src/VerifyByPhoneManager.php
@@ -6,6 +6,7 @@ namespace Worksome\VerifyByPhone;
 
 use Illuminate\Support\Manager;
 use Twilio\Rest\Client;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
 use Worksome\VerifyByPhone\Services\FakeVerificationService;
 use Worksome\VerifyByPhone\Services\Twilio\TwilioVerificationService;
 
@@ -28,10 +29,15 @@ class VerifyByPhoneManager extends Manager
     {
         /** @var Client $client */
         $client = $this->container->make(Client::class);
+        /** @var VerificationCodeManager $verificationCodeManager */
+        $verificationCodeManager = $this->container->make(VerificationCodeManager::class);
+
+        $generateCodeLocally = boolval($this->config->get('verify-by-phone.services.twilio.generate_code_locally'));
 
         return new TwilioVerificationService(
             $client,
             strval($this->config->get('verify-by-phone.services.twilio.verify_sid')),
+            $generateCodeLocally ? $verificationCodeManager : null
         );
     }
 }

--- a/src/VerifyByPhoneManager.php
+++ b/src/VerifyByPhoneManager.php
@@ -32,7 +32,7 @@ class VerifyByPhoneManager extends Manager
         /** @var VerificationCodeManager $verificationCodeManager */
         $verificationCodeManager = $this->container->make(VerificationCodeManager::class);
 
-        $generateCodeLocally = boolval($this->config->get('verify-by-phone.services.twilio.generate_code_locally'));
+        $generateCodeLocally = boolval($this->config->get('verify-by-phone.services.twilio.generate_codes_locally', false));
 
         return new TwilioVerificationService(
             $client,

--- a/src/VerifyByPhoneServiceProvider.php
+++ b/src/VerifyByPhoneServiceProvider.php
@@ -13,9 +13,11 @@ use Worksome\VerifyByPhone\Commands\SendVerificationCodeCommand;
 use Worksome\VerifyByPhone\Commands\VerifyVerificationCodeCommand;
 use Worksome\VerifyByPhone\Contracts\PhoneVerificationService;
 use Worksome\VerifyByPhone\Contracts\VerificationCodeGenerator;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
 use Worksome\VerifyByPhone\Services\Twilio\TwilioHttpClient;
 use Worksome\VerifyByPhone\Validation\Rules\VerificationCodeIsValid;
 use Worksome\VerifyByPhone\VerificationCodeGenerators\NumericVerificationCodeGenerator;
+use Worksome\VerifyByPhone\VerificationCodeManagers\CacheVerificationCodeManager;
 
 /**
  * @internal
@@ -32,6 +34,7 @@ class VerifyByPhoneServiceProvider extends PackageServiceProvider
         });
 
         $this->app->singleton(VerificationCodeGenerator::class, NumericVerificationCodeGenerator::class);
+        $this->app->singleton(VerificationCodeManager::class, CacheVerificationCodeManager::class);
     }
 
     public function bootingPackage(): void

--- a/src/VerifyByPhoneServiceProvider.php
+++ b/src/VerifyByPhoneServiceProvider.php
@@ -12,8 +12,10 @@ use Twilio\Rest\Client;
 use Worksome\VerifyByPhone\Commands\SendVerificationCodeCommand;
 use Worksome\VerifyByPhone\Commands\VerifyVerificationCodeCommand;
 use Worksome\VerifyByPhone\Contracts\PhoneVerificationService;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeGenerator;
 use Worksome\VerifyByPhone\Services\Twilio\TwilioHttpClient;
 use Worksome\VerifyByPhone\Validation\Rules\VerificationCodeIsValid;
+use Worksome\VerifyByPhone\VerificationCodeGenerators\NumericVerificationCodeGenerator;
 
 /**
  * @internal
@@ -28,6 +30,8 @@ class VerifyByPhoneServiceProvider extends PackageServiceProvider
 
             return $manager->driver();
         });
+
+        $this->app->singleton(VerificationCodeGenerator::class, NumericVerificationCodeGenerator::class);
     }
 
     public function bootingPackage(): void

--- a/src/VerifyByPhoneServiceProvider.php
+++ b/src/VerifyByPhoneServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Worksome\VerifyByPhone;
 
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Validation\Rule;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -14,6 +15,8 @@ use Worksome\VerifyByPhone\Commands\VerifyVerificationCodeCommand;
 use Worksome\VerifyByPhone\Contracts\PhoneVerificationService;
 use Worksome\VerifyByPhone\Contracts\VerificationCodeGenerator;
 use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
+use Worksome\VerifyByPhone\Events\PhoneNumberVerified;
+use Worksome\VerifyByPhone\Listeners\InformServiceOfVerificationStatus;
 use Worksome\VerifyByPhone\Services\Twilio\TwilioHttpClient;
 use Worksome\VerifyByPhone\Validation\Rules\VerificationCodeIsValid;
 use Worksome\VerifyByPhone\VerificationCodeGenerators\NumericVerificationCodeGenerator;
@@ -48,9 +51,9 @@ class VerifyByPhoneServiceProvider extends PackageServiceProvider
             );
         });
 
-        Rule::macro('verificationCodeIsValid', function (string $field) {
-            return new VerificationCodeIsValid($field);
-        });
+        Rule::macro('verificationCodeIsValid', fn (string $field) => new VerificationCodeIsValid($field));
+
+        Event::listen(PhoneNumberVerified::class, InformServiceOfVerificationStatus::class);
     }
 
     public function configurePackage(Package $package): void

--- a/tests/Concerns/FakesTwilioRequests.php
+++ b/tests/Concerns/FakesTwilioRequests.php
@@ -95,4 +95,9 @@ trait FakesTwilioRequests
 
         Http::fake(['https://verify.twilio.com/v2/Services/*/VerificationCheck' => Http::response($body, 404)]);
     }
+
+    public function fakeUpdateVerificationRequest(): void
+    {
+        Http::fake(['https://verify.twilio.com/v2/Services/*/Verifications/*' => Http::response([])]);
+    }
 }

--- a/tests/Listeners/InformServiceOfVerificationStatusTest.php
+++ b/tests/Listeners/InformServiceOfVerificationStatusTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Worksome\VerifyByPhone\Events\PhoneNumberVerified;
+use Worksome\VerifyByPhone\Listeners\InformServiceOfVerificationStatus;
+
+beforeEach(function () {
+    $this->listener = $this->app->make(InformServiceOfVerificationStatus::class);
+});
+
+it('listens to the PhoneNumberVerified event', function () {
+    Event::fake();
+
+    Event::assertListening(PhoneNumberVerified::class, InformServiceOfVerificationStatus::class);
+});
+
+it('provides an exponential backoff', function () {
+    expect($this->listener->backoff())->toBe([1, 5, 10, 60, 60]);
+});

--- a/tests/VerificationCodeGenerator/NumericVerificationCodeGeneratorTest.php
+++ b/tests/VerificationCodeGenerator/NumericVerificationCodeGeneratorTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Propaganistas\LaravelPhone\PhoneNumber;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeGenerator;
+use Worksome\VerifyByPhone\VerificationCodeGenerators\NumericVerificationCodeGenerator;
+
+it('is the default implementation', function () {
+    expect($this->app->make(VerificationCodeGenerator::class))
+        ->toBeInstanceOf(NumericVerificationCodeGenerator::class);
+});
+
+it('generates a random 6 digit numeric code', function () {
+    $generator = fn() => (new NumericVerificationCodeGenerator())->generate(new PhoneNumber('+44 01234567890'));
+
+    expect(Collection::times(50, $generator)->unique())
+        ->toHaveCount(50)
+        ->each->toBeNumeric()->toHaveLength(6);
+});

--- a/tests/VerificationCodeManager/CacheVerificationCodeManagerTest.php
+++ b/tests/VerificationCodeManager/CacheVerificationCodeManagerTest.php
@@ -19,15 +19,17 @@ it('can store and retrieve the verification code', function () {
     expect($retrievedCode)->toBe($generatedCode);
 });
 
-it('expires after 5 minutes', function () {
+it('expires after 10 minutes', function () {
     $manager = new CacheVerificationCodeManager(
         $this->app->make('cache.store'),
         new NumericVerificationCodeGenerator(),
     );
 
     $manager->store(new PhoneNumber('+44 01234567890'));
-    $this->travel(60 * 5 + 1)->seconds();
-    $code = $manager->retrieve(new PhoneNumber('+44 01234567890'));
 
-    expect($code)->toBeNull();
+    $this->travel(60 * 10)->seconds();
+    expect($manager->retrieve(new PhoneNumber('+44 01234567890')))->not->toBeNull();
+
+    $this->travel(1)->seconds();
+    expect($manager->retrieve(new PhoneNumber('+44 01234567890')))->toBeNull();
 });

--- a/tests/VerificationCodeManager/CacheVerificationCodeManagerTest.php
+++ b/tests/VerificationCodeManager/CacheVerificationCodeManagerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Propaganistas\LaravelPhone\PhoneNumber;
+use Worksome\VerifyByPhone\Contracts\VerificationCodeManager;
+use Worksome\VerifyByPhone\VerificationCodeGenerators\NumericVerificationCodeGenerator;
+use Worksome\VerifyByPhone\VerificationCodeManagers\CacheVerificationCodeManager;
+
+it('is the default implementation', function () {
+    expect($this->app->make(VerificationCodeManager::class))
+        ->toBeInstanceOf(CacheVerificationCodeManager::class);
+});
+
+it('can store and retrieve the verification code', function () {
+    $manager = $this->app->make(CacheVerificationCodeManager::class);
+
+    $generatedCode = $manager->store(new PhoneNumber('+44 01234567890'));
+    $retrievedCode = $manager->retrieve(new PhoneNumber('+44 01234567890'));
+
+    expect($retrievedCode)->toBe($generatedCode);
+});
+
+it('expires after 5 minutes', function () {
+    $manager = new CacheVerificationCodeManager(
+        $this->app->make('cache.store'),
+        new NumericVerificationCodeGenerator(),
+    );
+
+    $manager->store(new PhoneNumber('+44 01234567890'));
+    $this->travel(60 * 5 + 1)->seconds();
+    $code = $manager->retrieve(new PhoneNumber('+44 01234567890'));
+
+    expect($code)->toBeNull();
+});


### PR DESCRIPTION
This PR adds support for generating local verification codes instead of having to make a HTTP request to Twilio to do so. This results in a faster verification process with the tradeoff of a higher potential of failure due to the fact that the user is now in charge of managing the verification.

Of course, we still need to inform Twilio that the verification was completed, so we introduce support for that in a queued listener that is dispatched after a verification occurs. This is implemented in such a way as to allow for additional services that work in the same way to plug into this lifecycle by implementing the `InformsServiceAfterVerification` contract.