### PR TITLE
Removes windows from CI matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.0,8.1]
         laravel: [8.*,9.*]
         stability: [prefer-lowest, prefer-stable]


### PR DESCRIPTION
Basically, Windows keeps [flaking out](https://github.com/worksome/verify-by-phone/actions/runs/2718691267) through no fault of our own. It could be to do with [this](https://github.com/php/php-src/pull/7929), but for the time being, there's no point worrying about it.