### PR TITLE
chore(deps): Laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2]
-        laravel: [9.*]
+        laravel: [9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -37,6 +42,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,18 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^9.46",
+        "illuminate/contracts": "^9.46|^10.0",
         "propaganistas/laravel-phone": "^5.0",
-        "spatie/laravel-package-tools": "^1.13",
+        "spatie/laravel-package-tools": "^1.14.1",
         "twilio/sdk": "^6.44"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5",
         "nunomaduro/collision": "^6.3",
-        "orchestra/testbench": "^7.18",
+        "orchestra/testbench": "^7.18|^8.0",
         "pestphp/pest": "^1.22.3",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "pestphp/pest-plugin-laravel": "^1.4",
         "pestphp/pest-plugin-parallel": "^1.2",
-        "spatie/laravel-ray": "^1.26",
         "worksome/coding-style": "^2.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^9.46|^10.0",
-        "propaganistas/laravel-phone": "^5.0",
+        "propaganistas/laravel-phone": "^5.0.3",
         "spatie/laravel-package-tools": "^1.14.1",
         "twilio/sdk": "^6.44"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5",
         "nunomaduro/collision": "^6.3",
-        "orchestra/testbench": "^7.18|^8.0",
+        "orchestra/testbench": "^7.22|^8.0",
         "pestphp/pest": "^1.22.3",
         "pestphp/pest-plugin-laravel": "^1.4",
         "pestphp/pest-plugin-parallel": "^1.2",


### PR DESCRIPTION
Adds support for the upcoming release of Laravel 10.

Note that we cannot support Laravel 10 until https://github.com/Propaganistas/Laravel-Phone releases support for it, as we depend on that package. I've created [a PR](https://github.com/Propaganistas/Laravel-Phone/pull/219) to add support, so we just need to wait on that being merged hopefully.

Once support is added, I'll bump the version constraint and everything should work.