### PR TITLE
Allow twilio whatsapp verify channel

### DIFF
--- a/src/Services/Twilio/TwilioVerificationService.php
+++ b/src/Services/Twilio/TwilioVerificationService.php
@@ -33,10 +33,10 @@ final class TwilioVerificationService implements PhoneVerificationService
         $this->verificationChecks = $twilio->verificationChecks;
     }
 
-    public function send(PhoneNumber $number): void
+    public function send(PhoneNumber $number, string $channel = 'sms'): void
     {
         try {
-            $this->verifications->create($number->formatE164(), 'sms');
+            $this->verifications->create($number->formatE164(), $channel);
         } catch (TwilioException $e) {
             throw match ($e->getCode()) {
                 self::ERROR_NUMBER_DOES_NOT_SUPPORT_SMS => UnsupportedNumberException::fromException($e),


### PR DESCRIPTION
Not ready yet hence creating a draft PR as i'm going to sleep, will add more commits in subsequent days/weeks.

But wanted some of your opinions 1st on your preferences on how you would prefer me to structure things.

My goal is this:

https://www.twilio.com/docs/verify/whatsapp

Then if it work well we can try add Vonage/Nexmo 1 which allow you to just press Yes or No in whatsapp to verify the phone number. Without the need for OTP code

https://developer.vonage.com/en/verify/verify-v2/guides/using-whatsapp-interactive

