### PR TITLE
feat: add support for `twilio/sdk` 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^11.0 || ^12.0",
         "propaganistas/laravel-phone": "^5.3.4",
         "spatie/laravel-package-tools": "^1.19",
-        "twilio/sdk": "^6.44 || ^7.0"
+        "twilio/sdk": "^6.44 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.8",


### PR DESCRIPTION
according to the [twilio/sdk Upgrade Guide](https://github.com/twilio/twilio-php/blob/main/UPGRADE.md), there are no breaking changes from 7.x to 8.x:

> [2023-03-25] 7.x.x to 8.x.x
> ---------------------------
> Twilio Php Helper Library’s major version 8.0.0 is now available. We ensured that you can upgrade to Php helper Library 8.0.0 version without any breaking changes of existing apis
> 
> Behind the scenes Php Helper is now auto-generated via OpenAPI with this release. This enables us to rapidly add new features and enhance consistency across versions and languages.
> We're pleased to inform you that version 8.0.0 adds support for the application/json content type in the request body.

I have dropped `^6.44` as I didn't find a reason why anybody would still want to use such an old legacy version. But feel free to re-add it, if you can still support it.