### PR TITLE
Fix compatibility with Twilio 8.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^11.0 || ^12.0",
         "propaganistas/laravel-phone": "^5.3.4",
         "spatie/laravel-package-tools": "^1.19",
-        "twilio/sdk": "^7.16 || ^8.5"
+        "twilio/sdk": "^8.5"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.8",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/contracts": "^11.0 || ^12.0",
         "propaganistas/laravel-phone": "^5.3.4",
         "spatie/laravel-package-tools": "^1.19",
-        "twilio/sdk": "^7.16 || ^8.4"
+        "twilio/sdk": "^7.16 || ^8.5"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.8",

--- a/src/Services/Twilio/TwilioHttpClient.php
+++ b/src/Services/Twilio/TwilioHttpClient.php
@@ -6,6 +6,7 @@ namespace Worksome\VerifyByPhone\Services\Twilio;
 
 use GuzzleHttp\Psr7\Query;
 use Illuminate\Support\Facades\Http;
+use Twilio\AuthStrategy\AuthStrategy;
 use Twilio\Http\Client;
 use Twilio\Http\Response;
 
@@ -23,9 +24,10 @@ final class TwilioHttpClient implements Client
         array $params = [],
         array $data = [],
         array $headers = [],
-        string|null $user = null,
-        string|null $password = null,
-        int|null $timeout = null,
+        ?string $user = null,
+        ?string $password = null,
+        ?int $timeout = null,
+        ?AuthStrategy $authStrategy = null
     ): Response {
         $body = Query::build($data, PHP_QUERY_RFC1738);
 

--- a/src/Services/Twilio/TwilioHttpClient.php
+++ b/src/Services/Twilio/TwilioHttpClient.php
@@ -24,10 +24,10 @@ final class TwilioHttpClient implements Client
         array $params = [],
         array $data = [],
         array $headers = [],
-        ?string $user = null,
-        ?string $password = null,
-        ?int $timeout = null,
-        ?AuthStrategy $authStrategy = null
+        string|null $user = null,
+        string|null $password = null,
+        int|null $timeout = null,
+        AuthStrategy|null $authStrategy = null
     ): Response {
         $body = Query::build($data, PHP_QUERY_RFC1738);
 


### PR DESCRIPTION
I did a composer update today and got this error later

Declaration of Worksome\VerifyByPhone\Services\Twilio\TwilioHttpClient::request(string $method, string $url, array $params = [], array $data = [], array $headers = [], ?string $user = null, ?string $password = null, ?int $timeout = null): Twilio\Http\Response must be compatible with Twilio\Http\Client::request(string $method, string $url, array $params = [], array $data = [], array $headers = [], ?string $user = null, ?string $password = null, ?int $timeout = null, ?Twilio\AuthStrategy\AuthStrategy $authStrategy = null): Twilio\Http\Response

I noticed Twilio is updated from 8.4.1 to 8.5.0 too

So i decide to make this PR to fix this

Not sure if u need to drop support for twilio 7