### PR TITLE
feat: migrate from `Rule` to `ValidationRule`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,15 +19,6 @@ parameters:
 			path: src/Services/Twilio/TwilioHttpClient.php
 
 		-
-			message: '''
-				#^Class Worksome\\VerifyByPhone\\Validation\\Rules\\VerificationCodeIsValid implements deprecated interface Illuminate\\Contracts\\Validation\\Rule\:
-				see ValidationRule$#
-			'''
-			identifier: class.implementsDeprecatedInterface
-			count: 1
-			path: src/Validation/Rules/VerificationCodeIsValid.php
-
-		-
 			message: '#^Parameter \#1 \$number of class Propaganistas\\LaravelPhone\\PhoneNumber constructor expects string(?:\|null)?, mixed given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
> [!Note]
> This should likely be released as `0.6.x` in case anyone is using the rule directly. For example:
> ```php
> new VerificationCodeIsValid($phoneNumber)->passes('verification_code', '1234');
> ```